### PR TITLE
CAKE-2062 Remove the 'view full site' link from the footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fandom-global-elements",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "main": "dist/fandom-elements.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/footer/templates/global-footer-bottom-bar.handlebars
+++ b/src/footer/templates/global-footer-bottom-bar.handlebars
@@ -2,9 +2,4 @@
     <div class="wds-global-footer__bottom-bar-row wds-has-padding">
         {{{license model.licensing_and_vertical.description communityName vertical}}}
     </div>
-    <div class="wds-global-footer__bottom-bar-row wds-has-border-top global-footer-full-site-link-wrapper">
-        <a id="global-footer-full-site-link" href="?useskin=oasis" rel="nofollow" class="wds-global-footer__button-link" data-tracking-label="full-site-link">
-            {{i18n 'global-footer-full-site-link' ns='design-system'}}
-        </a>
-    </div>
 </div>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CAKE-2062

In _most_ cases but specifically in the FC this link doesn't serve a purpose. This is what the footer looks like now.

![screen shot 2017-08-11 at 1 50 05 pm](https://user-images.githubusercontent.com/21621/29227599-1008f37c-7e9c-11e7-8774-db7f661edbdb.png)

@Wikia/cake 